### PR TITLE
TARGET_TOKENやタスクの通知をバックエンドに登録するエンドポイントの実装

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -40,6 +40,10 @@ tasks.named('test') {
 	useJUnitPlatform()
 }
 
+tasks.withType(JavaCompile) {
+    options.compilerArgs.add('-parameters')
+}
+
 openApi {
 	apiDocsUrl.set("http://localhost:8080/api/docs.yaml")
 	outputDir.set(file("../openapi"))

--- a/backend/src/main/java/com/team8/taaks/controller/NotificationTargetTokenController.java
+++ b/backend/src/main/java/com/team8/taaks/controller/NotificationTargetTokenController.java
@@ -1,0 +1,83 @@
+package com.team8.taaks.controller;
+
+import com.team8.taaks.dto.NotificationTargetTokenRequest;
+import com.team8.taaks.dto.NotificationTargetTokenResponse; // Added import
+import com.team8.taaks.model.NotificationTargetToken;
+import com.team8.taaks.model.TaakUser;
+import com.team8.taaks.repository.NotificationTargetTokenRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import jakarta.validation.Valid;
+import java.net.URI;
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/notification-target-token")
+public class NotificationTargetTokenController {
+
+    private final NotificationTargetTokenRepository notificationTargetTokenRepository;
+
+    public NotificationTargetTokenController(NotificationTargetTokenRepository notificationTargetTokenRepository) {
+        this.notificationTargetTokenRepository = notificationTargetTokenRepository;
+    }
+
+    private NotificationTargetTokenResponse mapToResponse(NotificationTargetToken token) {
+        return new NotificationTargetTokenResponse(
+                token.getId(),
+                token.getTargetToken(),
+                token.getUser().getId(), // Assuming you want to expose userId
+                token.getCreatedAt(),
+                token.getUpdatedAt()
+        );
+    }
+
+    @GetMapping
+    public ResponseEntity<Page<NotificationTargetTokenResponse>> getNotificationTargetTokens(
+            @AuthenticationPrincipal TaakUser user,
+            @RequestParam(name = "page", required = false, defaultValue = "0") int page,
+            @RequestParam(name = "size", required = false, defaultValue = "10") int size) {
+        Pageable pageable = Pageable.ofSize(size).withPage(page);
+        Page<NotificationTargetToken> tokens = notificationTargetTokenRepository.findAllByUserId(user.getId(), pageable);
+        Page<NotificationTargetTokenResponse> response = tokens.map(this::mapToResponse);
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping
+    public ResponseEntity<NotificationTargetTokenResponse> createNotificationTargetToken(
+            @AuthenticationPrincipal TaakUser user,
+            @Valid @RequestBody NotificationTargetTokenRequest request) {
+
+        Optional<NotificationTargetToken> existingTokenOpt = notificationTargetTokenRepository.findByTargetTokenAndUserId(request.targetToken(), user.getId());
+        if (existingTokenOpt.isPresent()) {
+            NotificationTargetToken existingToken = existingTokenOpt.get();
+            HttpHeaders responseHeaders = new HttpHeaders();
+            responseHeaders.setLocation(URI.create("/notification-target-token/" + existingToken.getId()));
+            return new ResponseEntity<>(mapToResponse(existingToken), responseHeaders, HttpStatus.OK);
+        }
+
+        NotificationTargetToken newToken = new NotificationTargetToken();
+        newToken.setUser(user);
+        newToken.setTargetToken(request.targetToken());
+        NotificationTargetToken savedToken = notificationTargetTokenRepository.save(newToken);
+
+        HttpHeaders responseHeaders = new HttpHeaders();
+        responseHeaders.setLocation(URI.create("/notification-target-token/" + savedToken.getId()));
+        return new ResponseEntity<>(mapToResponse(savedToken), responseHeaders, HttpStatus.CREATED);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<NotificationTargetTokenResponse> getNotificationTargetToken(
+            @AuthenticationPrincipal TaakUser user,
+            @PathVariable(name = "id") Long id) {
+        return notificationTargetTokenRepository.findByIdAndUserId(id, user.getId())
+                .map(this::mapToResponse)
+                .map(ResponseEntity::ok)
+                .orElse(new ResponseEntity<>(HttpStatus.NOT_FOUND));
+    }
+}

--- a/backend/src/main/java/com/team8/taaks/controller/TaskController.java
+++ b/backend/src/main/java/com/team8/taaks/controller/TaskController.java
@@ -11,7 +11,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.scheduling.config.Task;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;

--- a/backend/src/main/java/com/team8/taaks/dto/NotificationTargetTokenRequest.java
+++ b/backend/src/main/java/com/team8/taaks/dto/NotificationTargetTokenRequest.java
@@ -1,0 +1,8 @@
+package com.team8.taaks.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotBlank;
+
+public record NotificationTargetTokenRequest(
+    @NotBlank @JsonProperty("target_token") String targetToken
+) {}

--- a/backend/src/main/java/com/team8/taaks/dto/NotificationTargetTokenResponse.java
+++ b/backend/src/main/java/com/team8/taaks/dto/NotificationTargetTokenResponse.java
@@ -1,0 +1,11 @@
+package com.team8.taaks.dto;
+
+import java.time.OffsetDateTime;
+
+public record NotificationTargetTokenResponse(
+    Long id,
+    String targetToken,
+    Long userId, // Or a UserSummaryDto if you need more user details
+    OffsetDateTime createdAt,
+    OffsetDateTime updatedAt
+) {}

--- a/backend/src/main/java/com/team8/taaks/dto/TaskRemindarRequest.java
+++ b/backend/src/main/java/com/team8/taaks/dto/TaskRemindarRequest.java
@@ -1,9 +1,0 @@
-package com.team8.taaks.dto;
-
-import java.time.ZonedDateTime;
-
-public record TaskRemindarRequest(
-    Long task_id,
-    ZonedDateTime scheduled_at
-) {
-}

--- a/backend/src/main/java/com/team8/taaks/dto/TaskRemindarRequest.java
+++ b/backend/src/main/java/com/team8/taaks/dto/TaskRemindarRequest.java
@@ -1,0 +1,9 @@
+package com.team8.taaks.dto;
+
+import java.time.ZonedDateTime;
+
+public record TaskRemindarRequest(
+    Long task_id,
+    ZonedDateTime scheduled_at
+) {
+}

--- a/backend/src/main/java/com/team8/taaks/repository/NotificationTargetTokenRepository.java
+++ b/backend/src/main/java/com/team8/taaks/repository/NotificationTargetTokenRepository.java
@@ -2,6 +2,8 @@ package com.team8.taaks.repository;
 
 import com.team8.taaks.model.NotificationTargetToken;
 import com.team8.taaks.model.TaakUser;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -36,4 +38,8 @@ public interface NotificationTargetTokenRepository extends JpaRepository<Notific
      * @return An Optional containing the NotificationTargetToken if found, or an empty Optional otherwise.
      */
     Optional<NotificationTargetToken> findByTargetToken(String targetToken);
+
+    Page<NotificationTargetToken> findAllByUserId(Long userId, Pageable pageable);
+    Optional<NotificationTargetToken> findByIdAndUserId(Long id, Long userId);
+    Optional<NotificationTargetToken> findByTargetTokenAndUserId(String targetToken, Long userId);
 }

--- a/backend/src/main/java/com/team8/taaks/repository/TaskReminderRepository.java
+++ b/backend/src/main/java/com/team8/taaks/repository/TaskReminderRepository.java
@@ -35,4 +35,12 @@ public interface TaskReminderRepository extends JpaRepository<TaskReminder, Long
      * @return A list of TaskReminder entities scheduled before the given time.
      */
     List<TaskReminder> findByScheduledAtBefore(ZonedDateTime scheduledTime);
+
+    /**
+     * Finds all task reminders associated with a given task ID.
+     *
+     * @param taskId The ID of the task.
+     * @return A list of TaskReminder entities for the specified task ID.
+     */
+    List<TaskReminder> findAllByTaskId(Integer taskId);
 }

--- a/backend/src/main/java/com/team8/taaks/repository/TaskReminderRepository.java
+++ b/backend/src/main/java/com/team8/taaks/repository/TaskReminderRepository.java
@@ -43,4 +43,11 @@ public interface TaskReminderRepository extends JpaRepository<TaskReminder, Long
      * @return A list of TaskReminder entities for the specified task ID.
      */
     List<TaskReminder> findAllByTaskId(Integer taskId);
+
+    /**
+     * Deletes all task reminders associated with a given task ID.
+     *
+     * @param taskId The ID of the task whose reminders are to be deleted.
+     */
+    void deleteAllByTaskId(Integer taskId);
 }

--- a/frontend_react/src/shared/api/api-spec.ts
+++ b/frontend_react/src/shared/api/api-spec.ts
@@ -80,6 +80,38 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/notification-target-token": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["getNotificationTargetTokens"];
+        put?: never;
+        post: operations["createNotificationTargetToken"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/notification-target-token/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["getNotificationTargetToken"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/tasks": {
         parameters: {
             query?: never;
@@ -197,8 +229,40 @@ export interface components {
             token?: string;
             user?: components["schemas"]["UsersResponse"];
         };
+        NotificationTargetTokenRequest: {
+            target_token: string;
+        };
+        NotificationTargetTokenResponse: {
+            /** Format: date-time */
+            createdAt?: string;
+            /** Format: int64 */
+            id?: number;
+            targetToken?: string;
+            /** Format: date-time */
+            updatedAt?: string;
+            /** Format: int64 */
+            userId?: number;
+        };
         PageDiaryResponse: {
             content?: components["schemas"]["DiaryResponse"][];
+            empty?: boolean;
+            first?: boolean;
+            last?: boolean;
+            /** Format: int32 */
+            number?: number;
+            /** Format: int32 */
+            numberOfElements?: number;
+            pageable?: components["schemas"]["PageableObject"];
+            /** Format: int32 */
+            size?: number;
+            sort?: components["schemas"]["SortObject"];
+            /** Format: int64 */
+            totalElements?: number;
+            /** Format: int32 */
+            totalPages?: number;
+        };
+        PageNotificationTargetTokenResponse: {
+            content?: components["schemas"]["NotificationTargetTokenResponse"][];
             empty?: boolean;
             first?: boolean;
             last?: boolean;
@@ -581,6 +645,102 @@ export interface operations {
                 };
                 content: {
                     "*/*": components["schemas"]["LoginResponse"];
+                };
+            };
+            /** @description exception */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    getNotificationTargetTokens: {
+        parameters: {
+            query?: {
+                page?: number;
+                size?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["PageNotificationTargetTokenResponse"];
+                };
+            };
+            /** @description exception */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    createNotificationTargetToken: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["NotificationTargetTokenRequest"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["NotificationTargetTokenResponse"];
+                };
+            };
+            /** @description exception */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    getNotificationTargetToken: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["NotificationTargetTokenResponse"];
                 };
             };
             /** @description exception */

--- a/frontend_react/src/shared/api/api-spec.ts
+++ b/frontend_react/src/shared/api/api-spec.ts
@@ -322,6 +322,7 @@ export interface components {
             /** Format: int32 */
             loadScore?: number;
             memo?: string;
+            scheduledAt?: string[];
             title?: string;
         };
         TaskResponse: {
@@ -335,6 +336,7 @@ export interface components {
             /** Format: int32 */
             loadScore?: number;
             memo?: string;
+            scheduledAt?: string[];
             title?: string;
         };
         UsersResponse: {

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -738,6 +738,11 @@ components:
           format: int32
         memo:
           type: string
+        scheduledAt:
+          type: array
+          items:
+            type: string
+            format: date-time
         title:
           type: string
     TaskResponse:
@@ -759,6 +764,11 @@ components:
           format: int32
         memo:
           type: string
+        scheduledAt:
+          type: array
+          items:
+            type: string
+            format: date-time
         title:
           type: string
     UsersResponse:

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -256,6 +256,87 @@ paths:
           description: exception
       tags:
       - login-controller
+  /notification-target-token:
+    get:
+      operationId: getNotificationTargetTokens
+      parameters:
+      - in: query
+        name: page
+        required: false
+        schema:
+          type: integer
+          format: int32
+          default: 0
+      - in: query
+        name: size
+        required: false
+        schema:
+          type: integer
+          format: int32
+          default: 10
+      responses:
+        "200":
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/PageNotificationTargetTokenResponse"
+          description: OK
+        default:
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: exception
+      tags:
+      - notification-target-token-controller
+    post:
+      operationId: createNotificationTargetToken
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/NotificationTargetTokenRequest"
+        required: true
+      responses:
+        "200":
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/NotificationTargetTokenResponse"
+          description: OK
+        default:
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: exception
+      tags:
+      - notification-target-token-controller
+  /notification-target-token/{id}:
+    get:
+      operationId: getNotificationTargetToken
+      parameters:
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+          format: int64
+      responses:
+        "200":
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/NotificationTargetTokenResponse"
+          description: OK
+        default:
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: exception
+      tags:
+      - notification-target-token-controller
   /tasks:
     get:
       operationId: getTask
@@ -493,6 +574,31 @@ components:
           type: string
         user:
           $ref: "#/components/schemas/UsersResponse"
+    NotificationTargetTokenRequest:
+      type: object
+      properties:
+        target_token:
+          type: string
+          minLength: 1
+      required:
+      - target_token
+    NotificationTargetTokenResponse:
+      type: object
+      properties:
+        createdAt:
+          type: string
+          format: date-time
+        id:
+          type: integer
+          format: int64
+        targetToken:
+          type: string
+        updatedAt:
+          type: string
+          format: date-time
+        userId:
+          type: integer
+          format: int64
     PageDiaryResponse:
       type: object
       properties:
@@ -500,6 +606,38 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/DiaryResponse"
+        empty:
+          type: boolean
+        first:
+          type: boolean
+        last:
+          type: boolean
+        number:
+          type: integer
+          format: int32
+        numberOfElements:
+          type: integer
+          format: int32
+        pageable:
+          $ref: "#/components/schemas/PageableObject"
+        size:
+          type: integer
+          format: int32
+        sort:
+          $ref: "#/components/schemas/SortObject"
+        totalElements:
+          type: integer
+          format: int64
+        totalPages:
+          type: integer
+          format: int32
+    PageNotificationTargetTokenResponse:
+      type: object
+      properties:
+        content:
+          type: array
+          items:
+            $ref: "#/components/schemas/NotificationTargetTokenResponse"
         empty:
           type: boolean
         first:


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

### 概要 & 関連資料
<!-- issue番号を # の後に入れると PR merge 時に close される -->
- close #212 

### 変更内容
<!-- どのような変更をしたか -->
<!-- ex.) ユーザーがアプリを楽しく使えるようにタスク完了時にアニメーションをつけた -->

- タスク登録・更新時のエンドポイント(/tasks)で通知時刻を登録できるようにします
- TARGET_TOKENを取得、追加、削除するためのエンドポイント(/notification-target-token)も追加します

### 影響範囲
<!-- どの画面に影響するか -->
<!-- ex.) タスク一覧画面 -->

- タスクの登録編集
- 通知

### 備考
<!-- レビューに関してのコメントなど -->
<!-- ex.) ダークモードへの対応はできてないが、後で対応するのでスルーして下さい -->
<!-- ex.) 動作確認のためには、.envにENV=trueを追記して下さい -->

- 

### セルフチェック
- [x] 環境変数などがPRに含まれていないか

<!-- I want to review in Japanese. -->
