### PR TITLE
タスクを登録する際に通知時刻を設定しないとエラーが出るバグの対応 #229

### DIFF
--- a/backend/src/main/java/com/team8/taaks/controller/TaskController.java
+++ b/backend/src/main/java/com/team8/taaks/controller/TaskController.java
@@ -208,13 +208,18 @@ public class TaskController {
         task.setCompletedAt(taskRequest.getCompletedAt());
         task.setLoadScore(taskRequest.getLoadScore());
         TaakTask registeredTask = taakTaskRepository.save(task);
-        taskReminderRepository.saveAll(taskRequest.getScheduledAt().stream()
-            .map(scheduledAt -> {
-                TaskReminder taskReminder = new TaskReminder();
-                taskReminder.setTask(registeredTask);
-                taskReminder.setScheduledAt(scheduledAt);
-                return taskReminder;
-            }).toList());
+        if(taskRequest.getScheduledAt() == null || taskRequest.getScheduledAt().isEmpty()) {
+            // スケジュールが指定されていない場合は空のリストを保存
+            taskReminderRepository.saveAll(List.of());
+        } else {
+            taskReminderRepository.saveAll(taskRequest.getScheduledAt().stream()
+                .map(scheduledAt -> {
+                    TaskReminder taskReminder = new TaskReminder();
+                    taskReminder.setTask(registeredTask);
+                    taskReminder.setScheduledAt(scheduledAt);
+                    return taskReminder;
+                }).toList());
+        }
         TaskResponse taskResponse = new TaskResponse();
         taskResponse.setId(registeredTask.getId());
         taskResponse.setTitle(registeredTask.getTitle());
@@ -251,13 +256,18 @@ public class TaskController {
         existingTask.setLoadScore(taskRequest.getLoadScore());
         taakTaskRepository.save(existingTask);
         taskReminderRepository.deleteAllByTaskId(taskId);
-        taskReminderRepository.saveAll(taskRequest.getScheduledAt().stream()
-            .map(scheduledAt -> {
-                TaskReminder taskReminder = new TaskReminder();
-                taskReminder.setTask(existingTask);
-                taskReminder.setScheduledAt(scheduledAt);
-                return taskReminder;
-            }).toList());
+                if(taskRequest.getScheduledAt() == null || taskRequest.getScheduledAt().isEmpty()) {
+            // スケジュールが指定されていない場合は空のリストを保存
+            taskReminderRepository.saveAll(List.of());
+        } else {
+            taskReminderRepository.saveAll(taskRequest.getScheduledAt().stream()
+                .map(scheduledAt -> {
+                    TaskReminder taskReminder = new TaskReminder();
+                    taskReminder.setTask(existingTask);
+                    taskReminder.setScheduledAt(scheduledAt);
+                    return taskReminder;
+                }).toList());
+        }
         return new ResponseEntity<>("Task updated successfully", HttpStatus.OK);
     }
 }

--- a/backend/src/main/java/com/team8/taaks/controller/TaskController.java
+++ b/backend/src/main/java/com/team8/taaks/controller/TaskController.java
@@ -256,7 +256,7 @@ public class TaskController {
         existingTask.setLoadScore(taskRequest.getLoadScore());
         taakTaskRepository.save(existingTask);
         taskReminderRepository.deleteAllByTaskId(taskId);
-                if(taskRequest.getScheduledAt() == null || taskRequest.getScheduledAt().isEmpty()) {
+        if(taskRequest.getScheduledAt() == null || taskRequest.getScheduledAt().isEmpty()) {
             // スケジュールが指定されていない場合は空のリストを保存
             taskReminderRepository.saveAll(List.of());
         } else {


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

### 概要 & 関連資料
<!-- issue番号を # の後に入れると PR merge 時に close される -->
- close #229 

### 変更内容
<!-- どのような変更をしたか -->
<!-- ex.) ユーザーがアプリを楽しく使えるようにタスク完了時にアニメーションをつけた -->

- タスクを登録、修正する際にscheduledAtが指定されていない場合の処理を追加しました

### 影響範囲
<!-- どの画面に影響するか -->
<!-- ex.) タスク一覧画面 -->

- タスク登録画面

### 備考
<!-- レビューに関してのコメントなど -->
<!-- ex.) ダークモードへの対応はできてないが、後で対応するのでスルーして下さい -->
<!-- ex.) 動作確認のためには、.envにENV=trueを追記して下さい -->

- 

### セルフチェック
- [x] 環境変数などがPRに含まれていないか

<!-- I want to review in Japanese. -->
