### PR TITLE
ユーザーの新規登録画面を作成

### DIFF
--- a/frontend_react/src/app/routes/_auth/register.tsx
+++ b/frontend_react/src/app/routes/_auth/register.tsx
@@ -1,0 +1,138 @@
+import { $api } from '@/shared/api/openapi-fetch';
+import { Button } from '@/shared/ui/components/shadcn/button';
+import {
+  Card,
+  CardContent,
+  CardFooter,
+  CardTitle,
+} from '@/shared/ui/components/shadcn/card';
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/shared/ui/components/shadcn/form';
+import { Input } from '@/shared/ui/components/shadcn/input';
+import { useMemo } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useQueryClient } from '@tanstack/react-query';
+import { createFileRoute, Link, useNavigate } from '@tanstack/react-router';
+import { LucideChevronLeft } from 'lucide-react';
+import { z } from 'zod';
+
+export const Route = createFileRoute('/_auth/register')({
+  component: RouteComponent,
+});
+
+const formSchema = z.object({
+  username: z.string(),
+  password: z
+    .string()
+    .min(12, { message: 'パスワードは12文字以上で入力してください' }),
+});
+
+function RouteComponent() {
+  const queryClient = useQueryClient();
+  const navigate = useNavigate();
+
+  const { mutate, isPending, error } = $api.useMutation('post', '/users', {
+    onSuccess: async (data) => {
+      const token = data.token;
+      if (!token) return;
+      // トークンをローカルストレージに保存
+      localStorage.setItem('token', token);
+      // ユーザー情報のキャッシュを更新
+      queryClient.invalidateQueries($api.queryOptions('get', '/users/me'));
+
+      // ダッシュボードにリダイレクト
+      navigate({
+        to: '/dashboard',
+      });
+    },
+  });
+
+  const form = useForm<z.infer<typeof formSchema>>({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      username: '',
+      password: '',
+    },
+    mode: 'onBlur',
+    reValidateMode: 'onChange',
+  });
+
+  const handleSubmit = useMemo(
+    () => form.handleSubmit((data) => mutate({ body: data })),
+    [mutate, form]
+  );
+
+  return (
+    <div className="flex w-full flex-col p-7">
+      <Form {...form}>
+        <form className="mt-auto" onSubmit={handleSubmit}>
+          <Card className="rounded-5xl gap-5 py-5">
+            <CardContent className="mb-[env(safe-area-inset-bottom)] space-y-5 px-5">
+              <CardTitle className="text-center">新規登録</CardTitle>
+              <FormField
+                control={form.control}
+                name="username"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>ユーザーID</FormLabel>
+                    <FormControl>
+                      <Input
+                        placeholder="ユーザーIDを入力してください"
+                        {...field}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="password"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>パスワード</FormLabel>
+                    <FormControl>
+                      <Input
+                        type="password"
+                        placeholder="パスワードを入力してください"
+                        {...field}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              {error && (
+                <div className="text-destructive">
+                  {error?.message ?? 'ログインに失敗しました'}
+                </div>
+              )}
+            </CardContent>
+            <CardFooter className="gap-2 px-5">
+              <Button size="icon-lg" className="size-14" asChild>
+                <Link to="/">
+                  <LucideChevronLeft />
+                </Link>
+              </Button>
+              <Button
+                size="lg"
+                type="submit"
+                className="h-14 flex-1"
+                disabled={isPending}
+              >
+                Taaks!をはじめる
+              </Button>
+            </CardFooter>
+          </Card>
+        </form>
+      </Form>
+    </div>
+  );
+}

--- a/frontend_react/src/app/routes/_auth/register.tsx
+++ b/frontend_react/src/app/routes/_auth/register.tsx
@@ -143,7 +143,7 @@ function RouteComponent() {
               />
               {error && (
                 <div className="text-destructive">
-                  {error?.message ?? 'ログインに失敗しました'}
+                  {error?.message ?? '登録に失敗しました'}
                 </div>
               )}
             </CardContent>

--- a/frontend_react/src/app/routes/index.tsx
+++ b/frontend_react/src/app/routes/index.tsx
@@ -44,7 +44,7 @@ function RouteComponent() {
 
       <div className="mt-auto mb-[env(safe-area-inset-bottom)] flex gap-4 p-7">
         <Button className="flex-1" size="lg" asChild>
-          <Link to="/login">はじめて使う</Link>
+          <Link to="/register">はじめて使う</Link>
         </Button>
         <Button className="flex-1" variant="outline" size="lg" asChild>
           <Link to="/login">ログイン</Link>

--- a/frontend_react/src/route-tree.gen.ts
+++ b/frontend_react/src/route-tree.gen.ts
@@ -18,6 +18,7 @@ import { Route as IndexImport } from './app/routes/index'
 import { Route as CreateBuddyIndexImport } from './app/routes/create-buddy/index'
 import { Route as CreateBuddyNicknameImport } from './app/routes/create-buddy/nickname'
 import { Route as CreateBuddyWithProgressImport } from './app/routes/create-buddy/_with-progress'
+import { Route as AuthRegisterImport } from './app/routes/_auth/register'
 import { Route as AuthLoginImport } from './app/routes/_auth/login'
 import { Route as AppTabTopPagesImport } from './app/routes/_app/_tab-top-pages'
 import { Route as CreateBuddyWithProgressHairImport } from './app/routes/create-buddy/_with-progress/hair'
@@ -71,6 +72,12 @@ const CreateBuddyNicknameRoute = CreateBuddyNicknameImport.update({
 const CreateBuddyWithProgressRoute = CreateBuddyWithProgressImport.update({
   id: '/_with-progress',
   getParentRoute: () => CreateBuddyRoute,
+} as any)
+
+const AuthRegisterRoute = AuthRegisterImport.update({
+  id: '/register',
+  path: '/register',
+  getParentRoute: () => AuthRoute,
 } as any)
 
 const AuthLoginRoute = AuthLoginImport.update({
@@ -198,6 +205,13 @@ declare module '@tanstack/react-router' {
       path: '/login'
       fullPath: '/login'
       preLoaderRoute: typeof AuthLoginImport
+      parentRoute: typeof AuthImport
+    }
+    '/_auth/register': {
+      id: '/_auth/register'
+      path: '/register'
+      fullPath: '/register'
+      preLoaderRoute: typeof AuthRegisterImport
       parentRoute: typeof AuthImport
     }
     '/create-buddy/_with-progress': {
@@ -339,10 +353,12 @@ const AppRouteWithChildren = AppRoute._addFileChildren(AppRouteChildren)
 
 interface AuthRouteChildren {
   AuthLoginRoute: typeof AuthLoginRoute
+  AuthRegisterRoute: typeof AuthRegisterRoute
 }
 
 const AuthRouteChildren: AuthRouteChildren = {
   AuthLoginRoute: AuthLoginRoute,
+  AuthRegisterRoute: AuthRegisterRoute,
 }
 
 const AuthRouteWithChildren = AuthRoute._addFileChildren(AuthRouteChildren)
@@ -389,6 +405,7 @@ export interface FileRoutesByFullPath {
   '': typeof AppTabTopPagesRouteWithChildren
   '/create-buddy': typeof CreateBuddyWithProgressRouteWithChildren
   '/login': typeof AuthLoginRoute
+  '/register': typeof AuthRegisterRoute
   '/create-buddy/nickname': typeof CreateBuddyNicknameRoute
   '/create-buddy/': typeof CreateBuddyIndexRoute
   '/buddy': typeof AppTabTopPagesBuddyRoute
@@ -408,6 +425,7 @@ export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '': typeof AppTabTopPagesRouteWithChildren
   '/login': typeof AuthLoginRoute
+  '/register': typeof AuthRegisterRoute
   '/create-buddy': typeof CreateBuddyIndexRoute
   '/create-buddy/nickname': typeof CreateBuddyNicknameRoute
   '/buddy': typeof AppTabTopPagesBuddyRoute
@@ -431,6 +449,7 @@ export interface FileRoutesById {
   '/create-buddy': typeof CreateBuddyRouteWithChildren
   '/_app/_tab-top-pages': typeof AppTabTopPagesRouteWithChildren
   '/_auth/login': typeof AuthLoginRoute
+  '/_auth/register': typeof AuthRegisterRoute
   '/create-buddy/_with-progress': typeof CreateBuddyWithProgressRouteWithChildren
   '/create-buddy/nickname': typeof CreateBuddyNicknameRoute
   '/create-buddy/': typeof CreateBuddyIndexRoute
@@ -454,6 +473,7 @@ export interface FileRouteTypes {
     | ''
     | '/create-buddy'
     | '/login'
+    | '/register'
     | '/create-buddy/nickname'
     | '/create-buddy/'
     | '/buddy'
@@ -472,6 +492,7 @@ export interface FileRouteTypes {
     | '/'
     | ''
     | '/login'
+    | '/register'
     | '/create-buddy'
     | '/create-buddy/nickname'
     | '/buddy'
@@ -493,6 +514,7 @@ export interface FileRouteTypes {
     | '/create-buddy'
     | '/_app/_tab-top-pages'
     | '/_auth/login'
+    | '/_auth/register'
     | '/create-buddy/_with-progress'
     | '/create-buddy/nickname'
     | '/create-buddy/'
@@ -554,7 +576,8 @@ export const routeTree = rootRoute
     "/_auth": {
       "filePath": "_auth.tsx",
       "children": [
-        "/_auth/login"
+        "/_auth/login",
+        "/_auth/register"
       ]
     },
     "/create-buddy": {
@@ -578,6 +601,10 @@ export const routeTree = rootRoute
     },
     "/_auth/login": {
       "filePath": "_auth/login.tsx",
+      "parent": "/_auth"
+    },
+    "/_auth/register": {
+      "filePath": "_auth/register.tsx",
       "parent": "/_auth"
     },
     "/create-buddy/_with-progress": {


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

### 概要 & 関連資料
<!-- issue番号を # の後に入れると PR merge 時に close される -->
- close #58 

### 変更内容
<!-- どのような変更をしたか -->
<!-- ex.) ユーザーがアプリを楽しく使えるようにタスク完了時にアニメーションをつけた -->

- アカウントの新規登録が行えるように実装

### 影響範囲
<!-- どの画面に影響するか -->
<!-- ex.) タスク一覧画面 -->

- _authディレクトリの配下に register.tsx を作成

### 備考
<!-- レビューに関してのコメントなど -->
<!-- ex.) ダークモードへの対応はできてないが、後で対応するのでスルーして下さい -->
<!-- ex.) 動作確認のためには、.envにENV=trueを追記して下さい -->

- login.tsxをほぼコピペで作りました
  - APIのエンドポイントを変更
  - 画面に表示する文言を僅かに変更
  - passwordの長さを12文字以上にすることを求める

### セルフチェック
- [ ] 環境変数などがPRに含まれていないか

<!-- I want to review in Japanese. -->
